### PR TITLE
Setup / server session issues

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .env
+.venv
 venv/
 *.key
 *.key.pub

--- a/server.py
+++ b/server.py
@@ -34,13 +34,13 @@ def handle_client(client_socket):
 
     channel = transport.accept()
     if channel is not None:
-        channel.send("Welcome to the SSH Server")
+        channel.send("Welcome to the SSH Server\r\n")
         while True:
             command = channel.recv(1024).decode('utf-8')
             if command.strip() == "exit":
                 break
             else:
-                channel.send(f"Command received: {command}\n")
+                channel.send(f"Command received: {command}\r\n")
 
         channel.close()
 

--- a/server.py
+++ b/server.py
@@ -19,6 +19,12 @@ class SimpleSSHServer(paramiko.ServerInterface):
         if username == 'user' and password == 'password':
             return paramiko.AUTH_SUCCESSFUL
         return paramiko.AUTH_FAILED
+    
+    def check_channel_pty_request(self, channel, term, width, height, pixelwidth, pixelheight, modes):
+        return True
+    
+    def check_channel_shell_request(self, channel):
+        return True
 
 def handle_client(client_socket):
     transport = paramiko.Transport(client_socket)


### PR DESCRIPTION
Added exclusion in .gitignore, added methods on server class that were preventing session from being created, messed with the server responses...

It doesn't seem like the server is actually creating a shell for the channel, the client is just streaming input to the server. 
In the documentation it looks like the client needs to request the shell when the [transport is created](https://docs.paramiko.org/en/latest/api/transport.html)? which doesn't seem to work with what we have in mind (using a normal ssh connection to access a terminal game, not writing a client with paramiko). 